### PR TITLE
Update default filename

### DIFF
--- a/src/arguments.js
+++ b/src/arguments.js
@@ -149,7 +149,7 @@ function getOptions(options) {
     // Set default filename is not specified.
     commandOptions.filename = options.filename || process.env[ENV_VAR.FILENAME];
     commandOptions.filename = options.filename === DEFAULT_FILENAME
-        ? `${commandOptions.filename}-${commandOptions.time.toISOString()}.${commandOptions.format}`
+        ? `${commandOptions.filename}-${commandOptions.time.toISOString().replace(/:/g, '-')}.${commandOptions.format}`
         : `${commandOptions.filename}.${commandOptions.format}`;
 
     // Set width and height of the window


### PR DESCRIPTION
Signed-off-by: Rupal Mahajan <maharup@amazon.com>

### Description
Replacing `:` with `-` in filename because `:` is invalid character in windows filename.

### Issues Resolved
https://github.com/opensearch-project/reporting-cli/issues/15

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
