### PR TITLE
Fix the path for the artifacts

### DIFF
--- a/jenkins/release.JenkinsFile
+++ b/jenkins/release.JenkinsFile
@@ -8,13 +8,13 @@ standardReleasePipelineWithGenericTrigger(
     causeString: 'A tag was cut on opensearch-project/reporting-cli repository causing this workflow to run',
     downloadReleaseAsset: true,
     publishRelease: true) {
-        publishToNpm(
-            repository: 'https://github.com/opensearch-project/reporting-cli',
-            tag: "$tag"
-        )
+        // publishToNpm(
+        //     repository: 'https://github.com/opensearch-project/reporting-cli',
+        //     tag: "$tag"
+        // )
         publishToArtifactsProdBucket(
             assumedRoleName: 'reporting-cli-artifacts-upload-role',
-            source: 'reporting-cli',
+            source: "${WORKSPACE}/reporting-cli",
             destination: 'reporting-cli',
             signingPlatform: 'linux',
             sigType: '.sig'


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The current release workflow broke because of the path of the artifacts. Commenting out npm part as we already released on NPM. Will create another path to uncomment it after we release on artifacts.opensarch.org

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
