### PR TITLE
Fix for lambda not evaluating some environment variables

### DIFF
--- a/src/arguments.js
+++ b/src/arguments.js
@@ -89,11 +89,11 @@ async function getEventArguments(event) {
         event['width'] = DEFAULT_WIDTH;
     if (event.height === undefined)
         event['height'] = DEFAULT_MIN_HEIGHT;
-    if (event.filename === undefined)
+    if (event.filename === undefined && process.env[ENV_VAR.FILENAME] === undefined)
         event['filename'] = DEFAULT_FILENAME;
-    if (event.subject === undefined)
+    if (event.subject === undefined && process.env[ENV_VAR.EMAIL_SUBJECT] === undefined)
         event['subject'] = DEFAULT_EMAIL_SUBJECT;
-    if (event.note === undefined)
+    if (event.note === undefined && process.env[ENV_VAR.EMAIL_NOTE] === undefined)
         event['note'] = DEFAULT_EMAIL_NOTE;
     if (event.multitenancy === undefined)
         event['multitenancy'] = DEFAULT_MULTI_TENANCY;


### PR DESCRIPTION
### Description
- Updated condition while setting default values for lambda event. 
- Test this fix with updated docker image on lambda

### Issues Resolved
https://github.com/opensearch-project/reporting-cli/issues/38

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
