### PR TITLE
correct `SMTP_` environment variables

### DIFF
--- a/src/arguments.js
+++ b/src/arguments.js
@@ -206,8 +206,8 @@ function getOptions(options) {
     commandOptions.smtphost = options.smtphost || process.env[ENV_VAR.SMTP_HOST];
     commandOptions.smtpport = options.smtpport || process.env[ENV_VAR.SMTP_PORT];
     commandOptions.smtpsecure = options.smtpsecure || process.env[ENV_VAR.SMTP_SECURE];
-    commandOptions.smtpusername = options.smtpusername || process.env[ENV_VAR.USERNAME];
-    commandOptions.smtppassword = options.smtppassword || process.env[ENV_VAR.PASSWORD];
+    commandOptions.smtpusername = options.smtpusername || process.env[ENV_VAR.SMTP_USERNAME];
+    commandOptions.smtppassword = options.smtppassword || process.env[ENV_VAR.SMTP_PASSWORD];
 
     // Set email subject.
     commandOptions.subject = options.subject || process.env[ENV_VAR.EMAIL_SUBJECT];


### PR DESCRIPTION
### Description
documentation mentions these environment variables but they were not used in code
https://github.com/opensearch-project/reporting-cli/blob/95d4ef188e3220eced3c6b0ef15d34390d4622c2/USER_GUIDE.md?plain=1#L38-L39

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
